### PR TITLE
Use absolute imports for db and blueprints

### DIFF
--- a/MG_ERP_v2_updated/MG_ERP_v2_skeleton/app.py
+++ b/MG_ERP_v2_updated/MG_ERP_v2_skeleton/app.py
@@ -38,7 +38,7 @@ except ImportError:  # pragma: no cover
             )
             return self
 
-from .db import close_db
+from db import close_db
 
 
 def create_app() -> Flask:
@@ -67,7 +67,7 @@ def create_app() -> Flask:
     app.teardown_appcontext(close_db)
 
     # Register application blueprints
-    from .blueprints.main import bp as main_bp  # imported here to avoid circular imports
+    from blueprints.main import bp as main_bp  # imported here to avoid circular imports
     app.register_blueprint(main_bp)
 
     return app

--- a/MG_ERP_v2_updated/MG_ERP_v2_skeleton/blueprints/main.py
+++ b/MG_ERP_v2_updated/MG_ERP_v2_skeleton/blueprints/main.py
@@ -10,7 +10,7 @@ database helper from ``db.py`` to retrieve data.
 from flask import Blueprint, render_template
 import sqlite3
 
-from ..db import get_db
+from db import get_db
 
 
 bp = Blueprint("main", __name__)


### PR DESCRIPTION
## Summary
- replace relative imports in the Flask app factory with absolute imports so `python app.py` works when run from the project root
- update the main blueprint to import the database helper via the absolute module path

## Testing
- python app.py


------
https://chatgpt.com/codex/tasks/task_e_68ce36c4c1a08333b36a2be57acef4ba